### PR TITLE
perf: skip redundant bindTexture in setTextureAt

### DIFF
--- a/lib/webgl/TextureContextWebGL.ts
+++ b/lib/webgl/TextureContextWebGL.ts
@@ -25,6 +25,7 @@ export class TextureContextWebGL {
 	public static MAX_SAMPLERS = 16;
 
 	_lastBoundedTexture: TextureWebGL;
+	_activeTextureUnit: number = -1;
 	_samplerStates: SamplerStateWebGL[] = [];
 	_currentRT: RenderTargetWebGL = null;
 
@@ -112,7 +113,7 @@ export class TextureContextWebGL {
 
 		if (!texture) {
 			if (samplerState.type) {
-				gl.activeTexture(gl.TEXTURE0 + sampler);
+				this._activateTextureUnit(sampler);
 
 				// disable link to sampler in bounded texture
 				if (samplerState.boundedTexture) {
@@ -130,9 +131,12 @@ export class TextureContextWebGL {
 
 		const textureType = GL_MAP.TEXTURE[texture.textureType];
 		const alreadyBound = samplerState.boundedTexture === texture && samplerState.type === textureType;
+		// commit early-outs when wrap/filter already match texture._state
+		const paramsDirty = !alreadyBound || !samplerState.equals(texture._state);
 
-		// Always activate the sampler unit before commit (texParameteri needs it).
-		gl.activeTexture(gl.TEXTURE0 + sampler);
+		// Skip activeTexture when unit is active, texture already bound, params unchanged.
+		if (!alreadyBound || paramsDirty || this._activeTextureUnit !== sampler)
+			this._activateTextureUnit(sampler);
 
 		texture._state.id = sampler;
 
@@ -140,8 +144,16 @@ export class TextureContextWebGL {
 		this.bindTexture(texture, alreadyBound, textureType);
 
 		samplerState.commit(textureType, texture);
+		samplerState.boundedTexture = texture;
 
 		return sampler;
+	}
+
+	private _activateTextureUnit(sampler: number): void {
+		if (this._activeTextureUnit === sampler)
+			return;
+		this._activeTextureUnit = sampler;
+		this._gl.activeTexture(this._gl.TEXTURE0 + sampler);
 	}
 
 	public setSamplerStateAt(

--- a/lib/webgl/TextureContextWebGL.ts
+++ b/lib/webgl/TextureContextWebGL.ts
@@ -109,14 +109,10 @@ export class TextureContextWebGL {
 	public setTextureAt(sampler: number, texture: TextureWebGL): number {
 		const gl = this._context._gl;
 		const samplerState = this._samplerStates[sampler];
-		const textureType = GL_MAP.TEXTURE[texture.textureType];
-
-		if ((texture || samplerState.type)) {
-			gl.activeTexture(gl.TEXTURE0 + sampler);
-		}
 
 		if (!texture) {
 			if (samplerState.type) {
+				gl.activeTexture(gl.TEXTURE0 + sampler);
 
 				// disable link to sampler in bounded texture
 				if (samplerState.boundedTexture) {
@@ -132,9 +128,16 @@ export class TextureContextWebGL {
 			return -1;
 		}
 
+		const textureType = GL_MAP.TEXTURE[texture.textureType];
+		const alreadyBound = samplerState.boundedTexture === texture && samplerState.type === textureType;
+
+		// Always activate the sampler unit before commit (texParameteri needs it).
+		gl.activeTexture(gl.TEXTURE0 + sampler);
+
 		texture._state.id = sampler;
 
-		this.bindTexture(texture, false, textureType);
+		// Skip redundant GL bindTexture when this sampler already holds the texture.
+		this.bindTexture(texture, alreadyBound, textureType);
 
 		samplerState.commit(textureType, texture);
 


### PR DESCRIPTION
## Summary
- In `TextureContextWebGL.setTextureAt`, when the sampler already holds the requested texture, call `bindTexture` with `check=true` so the GL bind is skipped.
- Still activates the texture unit and runs `commit()` so wrap/filter updates remain correct.

## Measurements (Diggy_fixed, coolmath pixel-federation, with renderer E1)
| Metric | Baseline | This PR (E1+E2) | Delta |
|--|--|--|--|
| median frame ms | 99.9 | 99.9 | 0 |
| bindTexture/frame | 233.26 | **~0** | **-233** |
| draw/frame | 233.26 | 233.26 | 0 |

Frame time flat on Diggy (CPU/draw-bound at ~11 fps); clear GPU state-change proxy win.

## SWF compatibility
- Diggy title screen visual OK (960×720 canvas, PLAY UI, FPS overlay).

Companion: `@awayjs/renderer` PR https://github.com/awayjs/renderer/pull/35

## Test plan
- [ ] Diggy / Burrito / FireBoy on localhost awayfl host
- [ ] Confirm filters/RTT/mask paths still bind textures when sampler changes